### PR TITLE
If full url not found, try path

### DIFF
--- a/lib/server/index.coffee
+++ b/lib/server/index.coffee
@@ -218,10 +218,15 @@ module.exports = ->
 
     cleanUrl: (req) =>
       lowercaseUrl = req.url.toLowerCase()
-        .replace /([a-zA-Z])\/$/, '$1'
+        .replace /([a-z0-9])\/$/, '$1'
 
       if lowercaseUrl of @data
         return lowercaseUrl
+
+      lowercasePath = req.path.toLowerCase();
+
+      if lowercasePath of @data
+        return lowercasePath
 
       return req.url
 

--- a/test/lib/server/index_spec.coffee
+++ b/test/lib/server/index_spec.coffee
@@ -116,6 +116,7 @@ describe "Server/index", ->
 
       req =
         url: '/MYtestUrl'
+        path: '/MytestUrl'
         method: 'GET'
 
       server.customData = {}
@@ -156,6 +157,19 @@ describe "Server/index", ->
 
       server.respond req, res, ->
         throw new Error("Res.json not called")
+  describe "cleanUrl", ->
+    it "should remove trailing slash", ->
+      req =
+        url: '/path-with/trailing-slash/'
+      
+      server.data =
+        '/path-with/trailing-slash':
+          something: 'something'
+      
+      result = server.cleanUrl req
+
+      expect(result).toBe '/path-with/trailing-slash'
+
   describe "getData", ->
     it "should retrieve override from customdata", ->
       server.customData =
@@ -176,6 +190,7 @@ describe "Server/index", ->
       res = server.getData({
         method: 'POST'
         url: '/override_url/api'
+        path: '/override_url/api'
       })
 
       expect(res.templateName).toBe('test.html')


### PR DESCRIPTION
* Enables querystrings to be ignored (as they are on the server)